### PR TITLE
chore: release v0.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.7](https://github.com/mamba-org/resolvo/compare/resolvo-v0.8.6...resolvo-v0.8.7) - 2025-01-13
+
+### Other
+
+- *(ci)* bump prefix-dev/rattler-build-action from 0.2.25 to 0.2.26 (#100)
+- simplify watchmap traversal (#98)
+
 ## [0.8.6](https://github.com/mamba-org/resolvo/compare/resolvo-v0.8.5...resolvo-v0.8.6) - 2025-01-08
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resolvo"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "ahash",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cpp", "tools/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.6"
+version = "0.8.7"
 authors = ["Adolfo Ochagavía <github@adolfo.ochagavia.nl>", "Bas Zalmstra <zalmstra.bas@gmail.com>", "Tim de Jager <tdejager89@gmail.com>"]
 homepage = "https://github.com/mamba-org/resolvo"
 repository = "https://github.com/mamba-org/resolvo"

--- a/cpp/Cargo.toml
+++ b/cpp/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
-resolvo = { version = "0.8.6", path = "../" }
+resolvo = { version = "0.8.7", path = "../" }
 
 [build-dependencies]
 anyhow = "1"


### PR DESCRIPTION
## 🤖 New release
* `resolvo`: 0.8.6 -> 0.8.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.7](https://github.com/mamba-org/resolvo/compare/resolvo-v0.8.6...resolvo-v0.8.7) - 2025-01-13

### Other

- *(ci)* bump prefix-dev/rattler-build-action from 0.2.25 to 0.2.26 (#100)
- simplify watchmap traversal (#98)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).