### PR TITLE
Avoid panic in Itertools::format_with

### DIFF
--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -572,6 +572,7 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
                         self.clauses.kinds[derived_from.to_usize()]
                             .display(&self.variable_map, self.provider()),
                     )))
+                    .to_string()
             );
             tracing::debug!("====");
 


### PR DESCRIPTION
Run this new test by itself with `cargo test test_tracing`.

When tracing is configured with multiple output channels, it is possible for the `tracing::debug!` macro to call `fmt` multiple times on its arguments.

`format_with` is documented to panic if formatted more than once. https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.format_with

The panic can be avoided by adding `.to_string()` to the end of the use of `format_with` around line 569 of solver/mod.rs, but this may not be the best fix.

This test sets a global default which conflicts with tracing_test, so this new test doesn't play nice with the other tests when running the whole test suite.

Edit:

Test removed and the `to_string` fix has been put in place instead.