### PR TITLE
feat: add type for `HintDependenciesAvailable`

### DIFF
--- a/cpp/src/lib.rs
+++ b/cpp/src/lib.rs
@@ -4,7 +4,7 @@ mod vector;
 
 use std::{ffi::c_void, fmt::Display, ptr::NonNull};
 
-use resolvo::{KnownDependencies, SolverCache};
+use resolvo::{HintDependenciesAvailable, KnownDependencies, SolverCache};
 
 use crate::{slice::Slice, string::String, vector::Vector};
 
@@ -428,11 +428,13 @@ impl<'d> resolvo::DependencyProvider for &'d DependencyProvider {
                 candidates: candidates.candidates.into_iter().map(Into::into).collect(),
                 favored: candidates.favored.as_ref().copied().map(Into::into),
                 locked: candidates.locked.as_ref().copied().map(Into::into),
-                hint_dependencies_available: candidates
-                    .hint_dependencies_available
-                    .into_iter()
-                    .map(Into::into)
-                    .collect(),
+                hint_dependencies_available: HintDependenciesAvailable::Some(
+                    candidates
+                        .hint_dependencies_available
+                        .into_iter()
+                        .map(Into::into)
+                        .collect(),
+                ),
                 excluded: candidates
                     .excluded
                     .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ pub struct Candidates {
     /// also be the case that the solver doesnt actually need this
     /// information to form a solution. In general though, if the
     /// dependencies can easily be provided one should provide them up-front.
-    pub hint_dependencies_available: Vec<SolvableId>,
+    pub hint_dependencies_available: HintDependenciesAvailable,
 
     /// A list of solvables that are available but have been excluded from the
     /// solver. For example, a package might be excluded from the solver
@@ -180,6 +180,25 @@ pub struct Candidates {
     /// consider these solvables when forming a solution but will use
     /// them in the error message if no solution could be found.
     pub excluded: Vec<(SolvableId, StringId)>,
+}
+
+/// Defines for which candidates dependencies are available without the
+/// [`DependencyProvider`] having to perform extra work, e.g. it's cheap to
+/// request them.
+#[derive(Default, Clone, Debug)]
+pub enum HintDependenciesAvailable {
+    /// None of the dependencies are available up-front. The dependency provide
+    /// will have to do work to find the dependencies.
+    #[default]
+    None,
+
+    /// All the dependencies are available up-front. Querying them is cheap.
+    All,
+
+    /// Only the dependencies for the specified solvables are available.
+    /// Querying the dependencies for these solvables is cheap. Querying
+    /// dependencies for other solvables is expensive.
+    Some(Vec<SolvableId>),
 }
 
 /// Holds information about the dependencies of a package.

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -196,7 +196,7 @@ impl DependencySnapshot {
                     {
                         HintDependenciesAvailable::None => &candidates.candidates[0..0],
                         HintDependenciesAvailable::All => &candidates.candidates,
-                        HintDependenciesAvailable::Some(candidates) => &candidates,
+                        HintDependenciesAvailable::Some(candidates) => candidates,
                     };
                     available_hints.extend(hint_dependencies_available.iter().copied());
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -15,8 +15,9 @@ use ahash::HashSet;
 use futures::FutureExt;
 
 use crate::{
-    internal::arena::ArenaId, Candidates, Dependencies, DependencyProvider, Interner, Mapping,
-    NameId, Requirement, SolvableId, SolverCache, StringId, VersionSetId, VersionSetUnionId,
+    internal::arena::ArenaId, Candidates, Dependencies, DependencyProvider,
+    HintDependenciesAvailable, Interner, Mapping, NameId, Requirement, SolvableId, SolverCache,
+    StringId, VersionSetId, VersionSetUnionId,
 };
 
 /// A single solvable in a [`DependencySnapshot`].
@@ -190,7 +191,14 @@ impl DependencySnapshot {
                             queue.push_back(Element::String(reason));
                         }
                     }
-                    available_hints.extend(candidates.hint_dependencies_available.iter().copied());
+
+                    let hint_dependencies_available = match &candidates.hint_dependencies_available
+                    {
+                        HintDependenciesAvailable::None => &candidates.candidates[0..0],
+                        HintDependenciesAvailable::All => &candidates.candidates,
+                        HintDependenciesAvailable::Some(candidates) => &candidates,
+                    };
+                    available_hints.extend(hint_dependencies_available.iter().copied());
 
                     let package = Package {
                         name: display,
@@ -472,12 +480,14 @@ impl<'s> DependencyProvider for SnapshotProvider<'s> {
             favored: None,
             locked: None,
             excluded: package.excluded.clone(),
-            hint_dependencies_available: package
-                .solvables
-                .iter()
-                .copied()
-                .filter(|&s| self.solvable(s).hint_dependencies_available)
-                .collect(),
+            hint_dependencies_available: HintDependenciesAvailable::Some(
+                package
+                    .solvables
+                    .iter()
+                    .copied()
+                    .filter(|&s| self.solvable(s).hint_dependencies_available)
+                    .collect(),
+            ),
         })
     }
 

--- a/src/solver/cache.rs
+++ b/src/solver/cache.rs
@@ -11,7 +11,8 @@ use crate::{
         frozen_copy_map::FrozenCopyMap,
         id::{CandidatesId, DependenciesId},
     },
-    Candidates, Dependencies, DependencyProvider, NameId, Requirement, SolvableId, VersionSetId,
+    Candidates, Dependencies, DependencyProvider, HintDependenciesAvailable, NameId, Requirement,
+    SolvableId, VersionSetId,
 };
 
 /// Keeps a cache of previously computed and/or requested information about
@@ -124,7 +125,13 @@ impl<D: DependencyProvider> SolverCache<D> {
                         {
                             let mut hint_dependencies_available =
                                 self.hint_dependencies_available.borrow_mut();
-                            for hint_candidate in candidates.hint_dependencies_available.iter() {
+                            let dependencies_available_candidates =
+                                match &candidates.hint_dependencies_available {
+                                    HintDependenciesAvailable::None => &candidates.candidates[0..0],
+                                    HintDependenciesAvailable::All => &candidates.candidates,
+                                    HintDependenciesAvailable::Some(candidates) => &candidates,
+                                };
+                            for hint_candidate in dependencies_available_candidates.iter() {
                                 let idx = hint_candidate.to_usize();
                                 if hint_dependencies_available.len() <= idx {
                                     hint_dependencies_available.resize(idx + 1, false);

--- a/src/solver/cache.rs
+++ b/src/solver/cache.rs
@@ -129,7 +129,7 @@ impl<D: DependencyProvider> SolverCache<D> {
                                 match &candidates.hint_dependencies_available {
                                     HintDependenciesAvailable::None => &candidates.candidates[0..0],
                                     HintDependenciesAvailable::All => &candidates.candidates,
-                                    HintDependenciesAvailable::Some(candidates) => &candidates,
+                                    HintDependenciesAvailable::Some(candidates) => candidates,
                                 };
                             for hint_candidate in dependencies_available_candidates.iter() {
                                 let idx = hint_candidate.to_usize();


### PR DESCRIPTION
This PR adds an enum for `hint_dependencies_available` so that if dependencies are available for all dependencies there is no need to duplicate a vec.