### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.8.7](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.8.6...resolvo-v0.8.7) - 2025-04-14
+## [0.9.0](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.8.6...resolvo-v0.8.7) - 2025-04-14
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.7](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.8.6...resolvo-v0.8.7) - 2025-04-14
+
+### Added
+
+- add type for `HintDependenciesAvailable` ([#123](https://github.com/prefix-dev/resolvo/pull/123))
+
+### Other
+
+- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#119](https://github.com/prefix-dev/resolvo/pull/119))
+- *(ci)* bump MarcoIeni/release-plz-action from 0.5.100 to 0.5.104 ([#121](https://github.com/prefix-dev/resolvo/pull/121))
+- *(ci)* bump prefix-dev/setup-pixi from 0.8.3 to 0.8.7 ([#122](https://github.com/prefix-dev/resolvo/pull/122))
+- pin follow up ([#116](https://github.com/prefix-dev/resolvo/pull/116))
+- pin github actions ([#115](https://github.com/prefix-dev/resolvo/pull/115))
+- *(ci)* bump prefix-dev/setup-pixi from 0.8.1 to 0.8.3 ([#112](https://github.com/prefix-dev/resolvo/pull/112))
+- Avoid panic in Itertools::format_with ([#108](https://github.com/prefix-dev/resolvo/pull/108))
+- make the versions printed in the merge solvables unique ([#106](https://github.com/prefix-dev/resolvo/pull/106))
+- *(ci)* bump prefix-dev/rattler-build-action from 0.2.25 to 0.2.26 ([#100](https://github.com/prefix-dev/resolvo/pull/100))
+- simplify watchmap traversal ([#98](https://github.com/prefix-dev/resolvo/pull/98))
+
 ## [0.8.6](https://github.com/mamba-org/resolvo/compare/resolvo-v0.8.5...resolvo-v0.8.6) - 2025-01-08
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.0](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.8.6...resolvo-v0.8.7) - 2025-04-14
+## [0.9.0](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.8.6...resolvo-v0.9.0) - 2025-04-14
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resolvo"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "ahash",
  "async-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resolvo"
-version = "0.8.7"
+version = "0.9.0"
 dependencies = [
  "ahash",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cpp", "tools/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.7"
+version = "0.9.0"
 authors = ["Adolfo Ochagavía <github@adolfo.ochagavia.nl>", "Bas Zalmstra <zalmstra.bas@gmail.com>", "Tim de Jager <tdejager89@gmail.com>"]
 homepage = "https://github.com/mamba-org/resolvo"
 repository = "https://github.com/mamba-org/resolvo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cpp", "tools/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.6"
+version = "0.8.7"
 authors = ["Adolfo Ochagavía <github@adolfo.ochagavia.nl>", "Bas Zalmstra <zalmstra.bas@gmail.com>", "Tim de Jager <tdejager89@gmail.com>"]
 homepage = "https://github.com/mamba-org/resolvo"
 repository = "https://github.com/mamba-org/resolvo"

--- a/cpp/Cargo.toml
+++ b/cpp/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
-resolvo = { version = "0.8.7", path = "../" }
+resolvo = { path = "../" }
 
 [build-dependencies]
 anyhow = "1"

--- a/cpp/Cargo.toml
+++ b/cpp/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
-resolvo = { version = "0.8.6", path = "../" }
+resolvo = { version = "0.8.7", path = "../" }
 
 [build-dependencies]
 anyhow = "1"


### PR DESCRIPTION



## 🤖 New release

* `resolvo`: 0.8.6 -> 0.8.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.7](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.8.6...resolvo-v0.8.7) - 2025-04-14

### Added

- add type for `HintDependenciesAvailable` ([#123](https://github.com/prefix-dev/resolvo/pull/123))

### Other

- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#119](https://github.com/prefix-dev/resolvo/pull/119))
- *(ci)* bump MarcoIeni/release-plz-action from 0.5.100 to 0.5.104 ([#121](https://github.com/prefix-dev/resolvo/pull/121))
- *(ci)* bump prefix-dev/setup-pixi from 0.8.3 to 0.8.7 ([#122](https://github.com/prefix-dev/resolvo/pull/122))
- pin follow up ([#116](https://github.com/prefix-dev/resolvo/pull/116))
- pin github actions ([#115](https://github.com/prefix-dev/resolvo/pull/115))
- *(ci)* bump prefix-dev/setup-pixi from 0.8.1 to 0.8.3 ([#112](https://github.com/prefix-dev/resolvo/pull/112))
- Avoid panic in Itertools::format_with ([#108](https://github.com/prefix-dev/resolvo/pull/108))
- make the versions printed in the merge solvables unique ([#106](https://github.com/prefix-dev/resolvo/pull/106))
- *(ci)* bump prefix-dev/rattler-build-action from 0.2.25 to 0.2.26 ([#100](https://github.com/prefix-dev/resolvo/pull/100))
- simplify watchmap traversal ([#98](https://github.com/prefix-dev/resolvo/pull/98))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).