### PR TITLE
fix: bump ubuntu runner version

### DIFF
--- a/.github/workflows/cpp-test.yml
+++ b/.github/workflows/cpp-test.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macOS-latest, macOS-14, windows-latest ]
+        os: [ubuntu-22.04, macOS-latest, macOS-14, windows-latest ]
     runs-on: ${{ matrix.os }}
     needs: [ format ]
     steps:


### PR DESCRIPTION
We got the following error in CI

> This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

This PR bumps the runner to use ubuntu 22.04.