### PR TITLE
feat: formal verification of unsafe blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,6 @@ tracing-test = { version = "0.2.5", features = ["no-env-filter"] }
 tokio = { version = "1.42.0", features = ["time", "rt"] }
 resolvo = { path = ".", features = ["tokio", "version-ranges"] }
 serde_json = "1.0"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }

--- a/src/internal/id.rs
+++ b/src/internal/id.rs
@@ -3,7 +3,7 @@ use std::{
     num::NonZeroU32,
 };
 
-use crate::{Interner, internal::arena::ArenaId};
+use crate::{internal::arena::ArenaId, Interner};
 
 /// The id associated to a package name
 #[repr(transparent)]
@@ -165,6 +165,7 @@ impl ArenaId for DependenciesId {
 /// A unique identifier for a variable in the solver.
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+#[cfg_attr(kani, derive(kani::Arbitrary))]
 pub struct VariableId(u32);
 
 impl VariableId {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![cfg_attr(kani, feature(proc_macro_hygiene))]
+#![cfg_attr(kani, feature(stmt_expr_attributes))]
+
 //! Implements a SAT solver for dependency resolution based on the CDCL
 //! algorithm (conflict-driven clause learning)
 //!

--- a/src/solver/clause.rs
+++ b/src/solver/clause.rs
@@ -8,15 +8,15 @@ use std::{
 use elsa::FrozenMap;
 
 use crate::{
-    Interner, NameId, Requirement,
     internal::{
         arena::{Arena, ArenaId},
         id::{ClauseId, LearntClauseId, StringId, VersionSetId},
     },
     solver::{
-        VariableId, decision_map::DecisionMap, decision_tracker::DecisionTracker,
-        variable_map::VariableMap,
+        decision_map::DecisionMap, decision_tracker::DecisionTracker, variable_map::VariableMap,
+        VariableId,
     },
+    Interner, NameId, Requirement,
 };
 
 /// Represents a single clause in the SAT problem
@@ -821,5 +821,20 @@ mod test {
             std::mem::size_of::<Option<WatchedLiterals>>(),
             std::mem::size_of::<WatchedLiterals>()
         );
+    }
+}
+
+#[cfg(kani)]
+mod verification {
+    use super::*;
+
+    // TODO: Remove panic
+    #[kani::proof]
+    fn literal_from_usize_correct() {
+        let x: usize = kani::any();
+        // If we don't assume it, try_into will handle expectional situation by panicking
+        kani::assume(x < (u32::MAX as usize));
+        let y = Literal::from_usize(x);
+        assert_eq!(y.to_usize(), x);
     }
 }


### PR DESCRIPTION
This PR formally verifies of almost all unsafe blocks in code base. Related to #18. Covered unsafe blocks are correct in the sense described below. 

[Kani](https://model-checking.github.io/kani/getting-started.html) provides bit-precise bounded model checking of the given functions. This roughly means that it can prove that some assertion holds for all possible (bounded) cases. In particular, it can spot
1. out-of-bounds accesses,
2. actually-unsafe dereferencing of a raw pointer to invalid memory,
3. a division by zero error and an overflowing addition.

See [limitations](https://model-checking.github.io/kani/limitations.html) for things that Kani can not deal with.

Proofs for `debug_expect_unchecked` and `FrozenCopyMap` are omitted due to enormous resources needed for checking. The most resource heavy correctness proof of `Mapping` takes around 40GB of RAM.

Here's the last lines of the output of `/usr/bin/time -v cargo kani`:

```
Manual Harness Summary:
Complete - 7 successfully verified harnesses, 0 failures, 7 total.
        Command being timed: "cargo kani"
        User time (seconds): 999.49
        System time (seconds): 54.18
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 17:38.93
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 31144928
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 3
        Minor (reclaiming a frame) page faults: 41407989
        Voluntary context switches: 88457
        Involuntary context switches: 7903
        Swaps: 0
        File system inputs: 1056
        File system outputs: 2424552
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```