### PR TITLE
chore: release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.9.1...resolvo-v0.9.2) - 2025-06-20
+
+### Other
+
+- *(ci)* bump prefix-dev/setup-pixi from 0.8.8 to 0.8.10 ([#144](https://github.com/prefix-dev/resolvo/pull/144))
+- make ConflictGraph simplify public ([#147](https://github.com/prefix-dev/resolvo/pull/147))
+- add Clone to ConflictGraph ([#145](https://github.com/prefix-dev/resolvo/pull/145))
+- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#135](https://github.com/prefix-dev/resolvo/pull/135))
+- *(ci)* bump actions-rust-lang/setup-rust-toolchain ([#134](https://github.com/prefix-dev/resolvo/pull/134))
+- *(ci)* bump prefix-dev/setup-pixi from 0.8.7 to 0.8.8 ([#130](https://github.com/prefix-dev/resolvo/pull/130))
+- *(ci)* bump MarcoIeni/release-plz-action from 0.5.104 to 0.5.105 ([#129](https://github.com/prefix-dev/resolvo/pull/129))
+
 ## [0.9.1](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.9.0...resolvo-v0.9.1) - 2025-05-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,7 +990,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resolvo"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ahash",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cpp", "tools/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.1"
+version = "0.9.2"
 authors = [
     "Adolfo Ochagavía <github@adolfo.ochagavia.nl>",
     "Bas Zalmstra <zalmstra.bas@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `resolvo`: 0.9.1 -> 0.9.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.2](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.9.1...resolvo-v0.9.2) - 2025-06-20

### Other

- *(ci)* bump prefix-dev/setup-pixi from 0.8.8 to 0.8.10 ([#144](https://github.com/prefix-dev/resolvo/pull/144))
- make ConflictGraph simplify public ([#147](https://github.com/prefix-dev/resolvo/pull/147))
- add Clone to ConflictGraph ([#145](https://github.com/prefix-dev/resolvo/pull/145))
- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#135](https://github.com/prefix-dev/resolvo/pull/135))
- *(ci)* bump actions-rust-lang/setup-rust-toolchain ([#134](https://github.com/prefix-dev/resolvo/pull/134))
- *(ci)* bump prefix-dev/setup-pixi from 0.8.7 to 0.8.8 ([#130](https://github.com/prefix-dev/resolvo/pull/130))
- *(ci)* bump MarcoIeni/release-plz-action from 0.5.104 to 0.5.105 ([#129](https://github.com/prefix-dev/resolvo/pull/129))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).