### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.9.1...resolvo-v0.10.0) - 2025-07-23
+
+### Added
+
+- [**breaking**] add support for conditional dependencies ([#136](https://github.com/prefix-dev/resolvo/pull/136))
+
+### Other
+
+- *(ci)* bump MarcoIeni/release-plz-action from 0.5.108 to 0.5.109 ([#156](https://github.com/prefix-dev/resolvo/pull/156))
+- *(ci)* bump prefix-dev/setup-pixi from 0.8.11 to 0.8.12 ([#157](https://github.com/prefix-dev/resolvo/pull/157))
+- update all dependencies ([#154](https://github.com/prefix-dev/resolvo/pull/154))
+- *(ci)* bump prefix-dev/setup-pixi from 0.8.10 to 0.8.11 ([#155](https://github.com/prefix-dev/resolvo/pull/155))
+- bump petgrpah version ([#153](https://github.com/prefix-dev/resolvo/pull/153))
+- making graph structs public for external consumption ([#152](https://github.com/prefix-dev/resolvo/pull/152))
+- *(ci)* bump actions-rust-lang/setup-rust-toolchain ([#149](https://github.com/prefix-dev/resolvo/pull/149))
+- *(ci)* bump MarcoIeni/release-plz-action from 0.5.107 to 0.5.108 ([#150](https://github.com/prefix-dev/resolvo/pull/150))
+- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#141](https://github.com/prefix-dev/resolvo/pull/141))
+- *(ci)* bump MarcoIeni/release-plz-action from 0.5.105 to 0.5.107 ([#142](https://github.com/prefix-dev/resolvo/pull/142))
+- *(ci)* bump prefix-dev/setup-pixi from 0.8.8 to 0.8.10 ([#144](https://github.com/prefix-dev/resolvo/pull/144))
+- make ConflictGraph simplify public ([#147](https://github.com/prefix-dev/resolvo/pull/147))
+- add Clone to ConflictGraph ([#145](https://github.com/prefix-dev/resolvo/pull/145))
+- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#135](https://github.com/prefix-dev/resolvo/pull/135))
+- *(ci)* bump actions-rust-lang/setup-rust-toolchain ([#134](https://github.com/prefix-dev/resolvo/pull/134))
+- *(ci)* bump prefix-dev/setup-pixi from 0.8.7 to 0.8.8 ([#130](https://github.com/prefix-dev/resolvo/pull/130))
+- *(ci)* bump MarcoIeni/release-plz-action from 0.5.104 to 0.5.105 ([#129](https://github.com/prefix-dev/resolvo/pull/129))
+
 ## [0.9.1](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.9.0...resolvo-v0.9.1) - 2025-05-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resolvo"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "ahash",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cpp", "tools/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0"
 authors = [
     "Adolfo Ochagavía <github@adolfo.ochagavia.nl>",
     "Bas Zalmstra <zalmstra.bas@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `resolvo`: 0.9.1 -> 0.10.0 (⚠ API breaking changes)

### ⚠ `resolvo` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field DependencySnapshot.conditions in /tmp/.tmpqEBVcz/resolvo/src/snapshot.rs:122

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_added.ron

Failed in:
  trait method resolvo::Interner::resolve_condition in file /tmp/.tmpqEBVcz/resolvo/src/lib.rs:110
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.0](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.9.1...resolvo-v0.10.0) - 2025-07-23

### Added

- [**breaking**] add support for conditional dependencies ([#136](https://github.com/prefix-dev/resolvo/pull/136))

### Other

- *(ci)* bump MarcoIeni/release-plz-action from 0.5.108 to 0.5.109 ([#156](https://github.com/prefix-dev/resolvo/pull/156))
- *(ci)* bump prefix-dev/setup-pixi from 0.8.11 to 0.8.12 ([#157](https://github.com/prefix-dev/resolvo/pull/157))
- update all dependencies ([#154](https://github.com/prefix-dev/resolvo/pull/154))
- *(ci)* bump prefix-dev/setup-pixi from 0.8.10 to 0.8.11 ([#155](https://github.com/prefix-dev/resolvo/pull/155))
- bump petgrpah version ([#153](https://github.com/prefix-dev/resolvo/pull/153))
- making graph structs public for external consumption ([#152](https://github.com/prefix-dev/resolvo/pull/152))
- *(ci)* bump actions-rust-lang/setup-rust-toolchain ([#149](https://github.com/prefix-dev/resolvo/pull/149))
- *(ci)* bump MarcoIeni/release-plz-action from 0.5.107 to 0.5.108 ([#150](https://github.com/prefix-dev/resolvo/pull/150))
- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#141](https://github.com/prefix-dev/resolvo/pull/141))
- *(ci)* bump MarcoIeni/release-plz-action from 0.5.105 to 0.5.107 ([#142](https://github.com/prefix-dev/resolvo/pull/142))
- *(ci)* bump prefix-dev/setup-pixi from 0.8.8 to 0.8.10 ([#144](https://github.com/prefix-dev/resolvo/pull/144))
- make ConflictGraph simplify public ([#147](https://github.com/prefix-dev/resolvo/pull/147))
- add Clone to ConflictGraph ([#145](https://github.com/prefix-dev/resolvo/pull/145))
- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#135](https://github.com/prefix-dev/resolvo/pull/135))
- *(ci)* bump actions-rust-lang/setup-rust-toolchain ([#134](https://github.com/prefix-dev/resolvo/pull/134))
- *(ci)* bump prefix-dev/setup-pixi from 0.8.7 to 0.8.8 ([#130](https://github.com/prefix-dev/resolvo/pull/130))
- *(ci)* bump MarcoIeni/release-plz-action from 0.5.104 to 0.5.105 ([#129](https://github.com/prefix-dev/resolvo/pull/129))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).