### PR TITLE
fix: import lib name

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -126,7 +126,9 @@ install(
 if(BUILD_SHARED_LIBS)
   install(FILES $<TARGET_FILE:${resolvo_cpp_impl}> TYPE BIN)
   if(WIN32)
-    install(FILES $<TARGET_LINKER_FILE:${resolvo_cpp_impl}> TYPE LIB)
+    install(FILES $<TARGET_LINKER_FILE:${resolvo_cpp_impl}> 
+            TYPE LIB 
+            RENAME resolvo_cpp.lib)
   endif()
 else()
     install(FILES $<TARGET_FILE:${resolvo_cpp_impl}> TYPE LIB)

--- a/cpp/Cargo.toml
+++ b/cpp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "resolvo_cpp"
 description = "Resolvo C++ integration"
-version = "0.2.1"
+version = "0.3.0"
 authors.workspace = true
 keywords.workspace = true
 categories.workspace = true


### PR DESCRIPTION
This PR renames the import lib name on windows from `resolvo_cpp.dll.lib` to `resolvo_cpp.lib`. This is required to make rattler-build recognize this as the import library associated with the dll.