### PR TITLE
feat: add human and machine readable error output in json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,6 +883,7 @@ dependencies = [
  "hashbrown",
  "indexmap",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1196,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ readme.workspace = true
 
 [features]
 diagnostics = ["tabwriter", "human_bytes"]
+json = ["serde", "serde_json", "petgraph/serde-1"]
 
 [dependencies]
 ahash = "0.8.12"
@@ -41,6 +42,7 @@ tracing = "0.1.41"
 elsa = "1.11.2"
 bitvec = "1.0.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = { version = "1.0.142", optional = true }
 futures = { version = "0.3", default-features = false, features = ["alloc", "async-await"] }
 event-listener = "5.4"
 indexmap = "2"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -125,17 +125,21 @@ install(
 
 if(BUILD_SHARED_LIBS)
   if(WIN32)
-    install(FILES $<TARGET_FILE:${resolvo_cpp_impl}> DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(FILES $<TARGET_FILE:${resolvo_cpp_impl}>
+            DESTINATION ${CMAKE_INSTALL_BINDIR})
   else()
-    install(FILES $<TARGET_FILE:${resolvo_cpp_impl}> DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(FILES $<TARGET_FILE:${resolvo_cpp_impl}>
+            DESTINATION ${CMAKE_INSTALL_LIBDIR})
   endif()
   if(WIN32)
-    install(FILES $<TARGET_LINKER_FILE:${resolvo_cpp_impl}> 
-            DESTINATION ${CMAKE_INSTALL_LIBDIR} 
-            RENAME resolvo_cpp.lib)
+    install(
+      FILES $<TARGET_LINKER_FILE:${resolvo_cpp_impl}>
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      RENAME resolvo_cpp.lib)
   endif()
 else()
-    install(FILES $<TARGET_FILE:${resolvo_cpp_impl}> DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  install(FILES $<TARGET_FILE:${resolvo_cpp_impl}>
+          DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
 include(CMakePackageConfigHelpers)

--- a/cpp/src/lib.rs
+++ b/cpp/src/lib.rs
@@ -674,7 +674,7 @@ pub extern "C" fn resolvo_solve(
             *error = problem.display_user_friendly(&solver).to_string().into();
             false
         }
-        Err(resolvo::UnsolvableOrCancelled::Cancelled(cancelled)) => {
+        Err(resolvo::UnsolvableOrCancelled::Cancelled { reason: _ }) => {
             *error = String::from("cancelled");
             false
         }

--- a/examples/json_errors.rs
+++ b/examples/json_errors.rs
@@ -1,0 +1,229 @@
+//! Demonstrates machine-readable error format support in resolvo
+//!
+//! This example shows how to:
+//! 1. Handle dependency resolution errors programmatically
+//! 2. Serialize errors to JSON for integration with external tools
+//! 3. Use different error reporting formats
+//!
+//! Run with: cargo run --example json_errors --features json
+//! This will create error_examples.json with the exported error data
+
+use std::{collections::HashMap, fs};
+
+#[cfg(feature = "json")]
+use resolvo::{
+    Candidates, Dependencies, DependencyProvider, HintDependenciesAvailable, Interner,
+    KnownDependencies, NameId, Problem, Requirement, SolvableId, Solver, StringId,
+    UnsolvableOrCancelled, VersionSetId,
+};
+
+#[cfg(feature = "json")]
+#[derive(Debug)]
+struct ExampleProvider;
+
+#[cfg(feature = "json")]
+impl ExampleProvider {
+    fn new() -> Self {
+        Self
+    }
+}
+
+#[cfg(feature = "json")]
+impl Interner for ExampleProvider {
+    fn display_solvable(&self, _solvable: SolvableId) -> impl std::fmt::Display + '_ {
+        "example-package@1.0.0"
+    }
+
+    fn display_name(&self, _name: NameId) -> impl std::fmt::Display + '_ {
+        "example-package"
+    }
+
+    fn display_version_set(&self, _version_set: VersionSetId) -> impl std::fmt::Display + '_ {
+        ">=1.0.0"
+    }
+
+    fn display_string(&self, _string_id: StringId) -> impl std::fmt::Display + '_ {
+        "example string"
+    }
+
+    fn version_set_name(&self, _version_set: VersionSetId) -> NameId {
+        NameId(0)
+    }
+
+    fn solvable_name(&self, _solvable: SolvableId) -> NameId {
+        NameId(0)
+    }
+
+    fn version_sets_in_union(
+        &self,
+        _version_set_union: resolvo::VersionSetUnionId,
+    ) -> impl Iterator<Item = VersionSetId> {
+        std::iter::empty()
+    }
+
+    fn resolve_condition(&self, _condition: resolvo::ConditionId) -> resolvo::Condition {
+        resolvo::Condition::Requirement(VersionSetId(0))
+    }
+}
+
+#[cfg(feature = "json")]
+impl DependencyProvider for ExampleProvider {
+    async fn filter_candidates(
+        &self,
+        _candidates: &[SolvableId],
+        _version_set: VersionSetId,
+        _inverse: bool,
+    ) -> Vec<SolvableId> {
+        vec![]
+    }
+
+    async fn get_candidates(&self, _name: NameId) -> Option<Candidates> {
+        Some(Candidates {
+            candidates: vec![],
+            favored: None,
+            locked: None,
+            hint_dependencies_available: HintDependenciesAvailable::None,
+            excluded: vec![],
+        })
+    }
+
+    async fn sort_candidates(
+        &self,
+        _solver: &resolvo::SolverCache<Self>,
+        _solvables: &mut [SolvableId],
+    ) {
+    }
+
+    async fn get_dependencies(&self, _solvable: SolvableId) -> Dependencies {
+        Dependencies::Known(KnownDependencies::default())
+    }
+}
+
+#[cfg(feature = "json")]
+fn create_missing_dependency_error() -> (UnsolvableOrCancelled, Solver<ExampleProvider>) {
+    let provider = ExampleProvider::new();
+    let mut solver = Solver::new(provider);
+
+    let problem = Problem::new().requirements(vec![Requirement::Single(VersionSetId(1)).into()]);
+
+    match solver.solve(problem) {
+        Ok(_) => panic!("Expected error for missing dependency"),
+        Err(error) => (error, solver),
+    }
+}
+
+fn demonstrate_json_error_serialization() -> serde_json::Value {
+    #[cfg(feature = "json")]
+    let mut examples: HashMap<&str, serde_json::Value> = HashMap::new();
+    #[cfg(not(feature = "json"))]
+    let examples: HashMap<&str, serde_json::Value> = HashMap::new();
+
+    #[cfg(feature = "json")]
+    let (error, solver) = create_missing_dependency_error();
+
+    #[cfg(feature = "json")]
+    {
+        if let Ok(json) = error.to_json() {
+            examples.insert(
+                "unsolvable_compact",
+                serde_json::from_str::<serde_json::Value>(&json).unwrap(),
+            );
+
+            if let Ok(deserialized) = UnsolvableOrCancelled::from_json(&json) {
+                if !verify_lossless_conversion(&error, &deserialized) {
+                    eprintln!("Warning: Lossless conversion failed for unsolvable error");
+                }
+            }
+        }
+
+        if let UnsolvableOrCancelled::Unsolvable(conflict) = &error {
+            if let Ok(graph_json) = conflict.to_graph_json(&solver) {
+                examples.insert(
+                    "unsolvable_graph",
+                    serde_json::from_str::<serde_json::Value>(&graph_json).unwrap(),
+                );
+            }
+        }
+
+        let cancelled_scenarios = vec![
+            (
+                "User requested cancellation during package resolution".to_string(),
+                "cancelled_error",
+            ),
+            (
+                "Operation timed out after 30 seconds".to_string(),
+                "timeout_error",
+            ),
+            ("Network connection lost".to_string(), "network_error"),
+            (
+                "Insufficient memory to continue".to_string(),
+                "memory_error",
+            ),
+        ];
+
+        for (reason, key) in cancelled_scenarios {
+            let cancelled_error = UnsolvableOrCancelled::Cancelled { reason };
+
+            if let Ok(cancelled_json) = cancelled_error.to_json_pretty() {
+                if let Ok(deserialized_cancelled) =
+                    UnsolvableOrCancelled::from_json(&cancelled_json)
+                {
+                    if verify_lossless_conversion(&cancelled_error, &deserialized_cancelled) {
+                        examples.insert(
+                            key,
+                            serde_json::from_str::<serde_json::Value>(&cancelled_json).unwrap(),
+                        );
+                    } else {
+                        eprintln!("Warning: Lossless conversion failed for {}", key);
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(not(feature = "json"))]
+    {
+        eprintln!("JSON feature not enabled. Run with: --features json");
+    }
+
+    serde_json::to_value(examples).unwrap()
+}
+
+/// Verifies that two UnsolvableOrCancelled errors are functionally identical
+#[cfg(feature = "json")]
+fn verify_lossless_conversion(
+    original: &UnsolvableOrCancelled,
+    deserialized: &UnsolvableOrCancelled,
+) -> bool {
+    match (original, deserialized) {
+        (
+            UnsolvableOrCancelled::Unsolvable(orig_conflict),
+            UnsolvableOrCancelled::Unsolvable(deser_conflict),
+        ) => orig_conflict.clause_count() == deser_conflict.clause_count(),
+        (
+            UnsolvableOrCancelled::Cancelled {
+                reason: orig_reason,
+            },
+            UnsolvableOrCancelled::Cancelled {
+                reason: deser_reason,
+            },
+        ) => orig_reason == deser_reason,
+        _ => false,
+    }
+}
+
+fn main() {
+    let json_examples = demonstrate_json_error_serialization();
+
+    let json_output = serde_json::json!({
+        "title": "Resolvo Machine-Readable Error Examples",
+        "description": "Examples of JSON-serialized error formats from resolvo dependency solver",
+        "examples": json_examples
+    });
+
+    let json_string = serde_json::to_string_pretty(&json_output).unwrap();
+    fs::write("examples/jsonoutput/error_examples.json", &json_string)
+        .expect("Failed to write JSON file");
+
+    println!("Examples exported to examples/jsonoutput/error_examples.json");
+}

--- a/examples/jsonoutput/error_examples.json
+++ b/examples/jsonoutput/error_examples.json
@@ -1,0 +1,63 @@
+{
+  "description": "Examples of JSON-serialized error formats from resolvo dependency solver",
+  "examples": {
+    "cancelled_error": {
+      "Cancelled": {
+        "reason": "User requested cancellation during package resolution"
+      }
+    },
+    "memory_error": {
+      "Cancelled": {
+        "reason": "Insufficient memory to continue"
+      }
+    },
+    "network_error": {
+      "Cancelled": {
+        "reason": "Network connection lost"
+      }
+    },
+    "timeout_error": {
+      "Cancelled": {
+        "reason": "Operation timed out after 30 seconds"
+      }
+    },
+    "unsolvable_compact": {
+      "Unsolvable": {
+        "clauses": [
+          2
+        ]
+      }
+    },
+    "unsolvable_graph": {
+      "graph": {
+        "edge_property": "directed",
+        "edges": [
+          [
+            0,
+            1,
+            {
+              "Requires": {
+                "single": 1
+              },
+              "display": "requires: example-package >=1.0.0"
+            }
+          ]
+        ],
+        "node_holes": [],
+        "nodes": [
+          {
+            "Solvable": 0,
+            "display": "<root>"
+          },
+          {
+            "UnresolvedDependency": null,
+            "display": "unresolved dependency"
+          }
+        ]
+      },
+      "root_node": 0,
+      "unresolved_node": 1
+    }
+  },
+  "title": "Resolvo Machine-Readable Error Examples"
+}

--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -11,6 +11,9 @@ use petgraph::{
     visit::{Bfs, DfsPostOrder, EdgeRef},
 };
 
+#[cfg(feature = "json")]
+use petgraph::visit::IntoNodeReferences;
+
 use crate::{
     DependencyProvider, Interner, Requirement,
     internal::{
@@ -23,6 +26,7 @@ use crate::{
 
 /// Represents the cause of the solver being unable to find a solution
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Conflict {
     /// The clauses involved in an unsatisfiable conflict
     clauses: Vec<ClauseId>,
@@ -214,10 +218,29 @@ impl Conflict {
         let graph = self.graph(solver);
         DisplayUnsat::new(graph, solver.provider())
     }
+
+    /// Returns the number of clauses involved in this conflict.
+    pub fn clause_count(&self) -> usize {
+        self.clauses.len()
+    }
+
+    /// Serialize the full conflict graph structure to JSON.
+    /// This includes the complete petgraph structure with nodes and edges plus embedded display information.
+    #[cfg(feature = "json")]
+    pub fn to_graph_json<D: DependencyProvider, RT: AsyncRuntime>(
+        &self,
+        solver: &Solver<D, RT>,
+    ) -> Result<String, serde_json::Error> {
+        let graph = self.graph(solver);
+        let enhanced_graph = DisplayEnhancedConflictGraph::from_graph(graph, solver);
+
+        serde_json::to_string_pretty(&enhanced_graph)
+    }
 }
 
 /// A node in the graph representation of a [`Conflict`]
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ConflictNode {
     /// Node corresponding to a solvable
     Solvable(SolvableOrRootId),
@@ -243,10 +266,40 @@ impl ConflictNode {
     fn solvable(self) -> Option<SolvableId> {
         self.solvable_or_root().solvable()
     }
+
+    /// Returns a type-safe display name for this conflict node
+    pub fn display_name<D: DependencyProvider, RT: AsyncRuntime>(
+        self,
+        solver: &Solver<D, RT>,
+    ) -> String {
+        match self {
+            ConflictNode::Solvable(solvable_id) => {
+                if solvable_id.is_root() {
+                    "<root>".to_string()
+                } else if let Some(solvable) = solvable_id.solvable() {
+                    solver
+                        .cache
+                        .provider()
+                        .display_solvable(solvable)
+                        .to_string()
+                } else {
+                    "unknown solvable".to_string()
+                }
+            }
+            ConflictNode::UnresolvedDependency => "unresolved dependency".to_string(),
+            ConflictNode::Excluded(string_id) => {
+                format!(
+                    "excluded: {}",
+                    solver.cache.provider().display_string(string_id)
+                )
+            }
+        }
+    }
 }
 
 /// An edge in the graph representation of a [`Conflict`]
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ConflictEdge {
     /// The target node is a candidate for the dependency specified by the
     /// [`Requirement`]
@@ -269,10 +322,22 @@ impl ConflictEdge {
             ConflictEdge::Conflict(_) => panic!("expected requires edge, found conflict"),
         }
     }
+
+    /// Returns a type-safe display name for this conflict edge
+    #[cfg(feature = "json")]
+    fn display_name<D: DependencyProvider>(self, provider: &D) -> String {
+        match self {
+            ConflictEdge::Requires(requirement) => {
+                format!("requires: {}", requirement.display(provider))
+            }
+            ConflictEdge::Conflict(cause) => cause.display_name(provider),
+        }
+    }
 }
 
 /// Conflict causes
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ConflictCause {
     /// The solvable is locked
     Locked(SolvableId),
@@ -282,6 +347,99 @@ pub enum ConflictCause {
     ForbidMultipleInstances,
     /// The node was excluded
     Excluded,
+}
+
+impl ConflictCause {
+    /// Returns a type-safe display name for this conflict cause
+    #[cfg(feature = "json")]
+    fn display_name<D: DependencyProvider>(self, provider: &D) -> String {
+        match self {
+            ConflictCause::Locked(solvable_id) => {
+                format!("locked: {}", provider.display_solvable(solvable_id))
+            }
+            ConflictCause::Constrains(version_set_id) => {
+                format!(
+                    "constrains: {}",
+                    provider.display_version_set(version_set_id)
+                )
+            }
+            ConflictCause::ForbidMultipleInstances => "multiple instances forbidden".to_string(),
+            ConflictCause::Excluded => "excluded".to_string(),
+        }
+    }
+}
+
+/// Display-enhanced versions of the conflict structures for JSON serialization
+#[cfg(feature = "json")]
+#[derive(serde::Serialize)]
+pub struct DisplayEnhancedConflictGraph {
+    /// The conflict graph as a directed petgraph with display-enhanced nodes and edges
+    pub graph: DiGraph<DisplayEnhancedConflictNode, DisplayEnhancedConflictEdge>,
+    /// The single source node for root constraints introduced to the solver
+    pub root_node: NodeIndex,
+    /// A single sink node that consumes all unresolvable constraints
+    pub unresolved_node: Option<NodeIndex>,
+}
+
+#[cfg(feature = "json")]
+impl DisplayEnhancedConflictGraph {
+    /// Creates a display-enhanced conflict graph from a regular conflict graph
+    pub fn from_graph<D: DependencyProvider, RT: AsyncRuntime>(
+        graph: ConflictGraph,
+        solver: &Solver<D, RT>,
+    ) -> Self {
+        let mut enhanced_graph = DiGraph::new();
+        let mut node_mapping = std::collections::HashMap::new();
+
+        // Copy nodes with display information
+        for (node_idx, node) in graph.graph.node_references() {
+            let enhanced_node = DisplayEnhancedConflictNode {
+                data: *node,
+                display: node.display_name(solver),
+            };
+            let new_idx = enhanced_graph.add_node(enhanced_node);
+            node_mapping.insert(node_idx, new_idx);
+        }
+
+        // Copy edges with display information
+        for edge_ref in graph.graph.edge_references() {
+            let source = node_mapping[&edge_ref.source()];
+            let target = node_mapping[&edge_ref.target()];
+            let enhanced_edge = DisplayEnhancedConflictEdge {
+                data: *edge_ref.weight(),
+                display: edge_ref.weight().display_name(solver.cache.provider()),
+            };
+            enhanced_graph.add_edge(source, target, enhanced_edge);
+        }
+
+        Self {
+            graph: enhanced_graph,
+            root_node: node_mapping[&graph.root_node],
+            unresolved_node: graph.unresolved_node.map(|idx| node_mapping[&idx]),
+        }
+    }
+}
+
+/// A conflict node enhanced with human-readable display information for JSON serialization
+#[cfg(feature = "json")]
+#[derive(serde::Serialize)]
+pub struct DisplayEnhancedConflictNode {
+    /// The original conflict node data
+    #[serde(flatten)]
+    pub data: ConflictNode,
+    /// Human-readable display name
+    pub display: String,
+}
+
+/// A conflict edge enhanced with human-readable display information for JSON serialization
+#[cfg(feature = "json")]
+#[derive(serde::Serialize)]
+pub struct DisplayEnhancedConflictEdge {
+    /// The original conflict edge data
+    #[serde(flatten)]
+    pub data: ConflictEdge,
+    /// Human-readable display name
+    pub display: String,
 }
 
 /// Represents a node that has been merged with others
@@ -303,6 +461,7 @@ pub struct MergedConflictNode {
 /// solvable's requirements are included in the graph, only those that are
 /// directly or indirectly involved in the conflict.
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConflictGraph {
     /// The conflict graph as a directed petgraph.
     pub graph: DiGraph<ConflictNode, ConflictEdge>,

--- a/src/internal/id.rs
+++ b/src/internal/id.rs
@@ -128,6 +128,8 @@ impl From<SolvableId> for u32 {
 
 #[repr(transparent)]
 #[derive(Copy, Clone, PartialOrd, Ord, Eq, PartialEq, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub(crate) struct ClauseId(NonZeroU32);
 
 impl ClauseId {
@@ -241,6 +243,8 @@ impl<I: Interner> Display for DisplaySolvableId<'_, I> {
 
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct SolvableOrRootId(u32);
 
 impl SolvableOrRootId {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,10 +19,7 @@ pub mod snapshot;
 mod solver;
 pub mod utils;
 
-use std::{
-    any::Any,
-    fmt::{Debug, Display},
-};
+use std::fmt::{Debug, Display};
 
 pub use conditional_requirement::{Condition, ConditionalRequirement, LogicalOperator};
 pub use internal::{
@@ -144,7 +141,7 @@ pub trait DependencyProvider: Sized + Interner {
     /// [Self::get_dependencies] and [Self::get_candidates]). If it returns
     /// `Some(...)`, the solver will stop and return
     /// [UnsolvableOrCancelled::Cancelled].
-    fn should_cancel_with_value(&self) -> Option<Box<dyn Any>> {
+    fn should_cancel_with_reason(&self) -> Option<String> {
         None
     }
 }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -9,7 +9,7 @@
 //! The [`DependencySnapshot`] implements the [`DependencyProvider`] trait,
 //! allowing it to be used as a dependency provider for the solver.
 
-use std::{any::Any, collections::VecDeque, fmt::Display, time::SystemTime};
+use std::{collections::VecDeque, fmt::Display, time::SystemTime};
 
 use ahash::HashSet;
 use futures::FutureExt;
@@ -137,7 +137,7 @@ impl DependencySnapshot {
         names: impl IntoIterator<Item = NameId>,
         version_sets: impl IntoIterator<Item = VersionSetId>,
         solvables: impl IntoIterator<Item = SolvableId>,
-    ) -> Result<Self, Box<dyn Any>> {
+    ) -> Result<Self, String> {
         Self::from_provider_async(provider, names, version_sets, solvables)
             .now_or_never()
             .expect(
@@ -154,7 +154,7 @@ impl DependencySnapshot {
         names: impl IntoIterator<Item = NameId>,
         version_sets: impl IntoIterator<Item = VersionSetId>,
         solvables: impl IntoIterator<Item = SolvableId>,
-    ) -> Result<Self, Box<dyn Any>> {
+    ) -> Result<Self, String> {
         #[derive(Hash, Copy, Clone, Debug, Eq, PartialEq)]
         pub enum Element {
             Solvable(SolvableId),
@@ -540,10 +540,10 @@ impl DependencyProvider for SnapshotProvider<'_> {
         self.solvable(solvable).dependencies.clone()
     }
 
-    fn should_cancel_with_value(&self) -> Option<Box<dyn Any>> {
+    fn should_cancel_with_reason(&self) -> Option<String> {
         if let Some(stop_time) = &self.stop_time {
             if SystemTime::now() > *stop_time {
-                return Some(Box::new(()));
+                return Some("Snapshot operation timed out".to_string());
             }
         }
         None

--- a/src/solver/cache.rs
+++ b/src/solver/cache.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, cell::RefCell, rc::Rc};
+use std::{cell::RefCell, rc::Rc};
 
 use ahash::HashMap;
 use bitvec::vec::BitVec;
@@ -79,7 +79,7 @@ impl<D: DependencyProvider> SolverCache<D> {
     pub async fn get_or_cache_candidates(
         &self,
         package_name: NameId,
-    ) -> Result<&Candidates, Box<dyn Any>> {
+    ) -> Result<&Candidates, String> {
         // If we already have the candidates for this package cached we can simply
         // return
         let candidates_id = match self.package_name_to_candidates.get_copy(&package_name) {
@@ -88,8 +88,8 @@ impl<D: DependencyProvider> SolverCache<D> {
                 // Since getting the candidates from the provider is a potentially blocking
                 // operation, we want to check beforehand whether we should cancel the solving
                 // process
-                if let Some(value) = self.provider.should_cancel_with_value() {
-                    return Err(value);
+                if let Some(reason) = self.provider.should_cancel_with_reason() {
+                    return Err(reason);
                 }
 
                 // Check if there is an in-flight request
@@ -172,7 +172,7 @@ impl<D: DependencyProvider> SolverCache<D> {
     pub async fn get_or_cache_matching_candidates(
         &self,
         version_set_id: VersionSetId,
-    ) -> Result<&[SolvableId], Box<dyn Any>> {
+    ) -> Result<&[SolvableId], String> {
         match self.version_set_candidates.get(&version_set_id) {
             Some(candidates) => Ok(candidates),
             None => {
@@ -210,7 +210,7 @@ impl<D: DependencyProvider> SolverCache<D> {
     pub async fn get_or_cache_non_matching_candidates(
         &self,
         version_set_id: VersionSetId,
-    ) -> Result<&[SolvableId], Box<dyn Any>> {
+    ) -> Result<&[SolvableId], String> {
         match self.version_set_inverse_candidates.get(&version_set_id) {
             Some(candidates) => Ok(candidates),
             None => {
@@ -255,7 +255,7 @@ impl<D: DependencyProvider> SolverCache<D> {
     pub async fn get_or_cache_sorted_candidates(
         &self,
         requirement: Requirement,
-    ) -> Result<&[SolvableId], Box<dyn Any>> {
+    ) -> Result<&[SolvableId], String> {
         match requirement {
             Requirement::Single(version_set_id) => {
                 self.get_or_cache_sorted_candidates_for_version_set(version_set_id)
@@ -294,7 +294,7 @@ impl<D: DependencyProvider> SolverCache<D> {
     pub(crate) async fn get_or_cache_sorted_candidates_for_version_set(
         &self,
         version_set_id: VersionSetId,
-    ) -> Result<&[SolvableId], Box<dyn Any>> {
+    ) -> Result<&[SolvableId], String> {
         let requirement = version_set_id.into();
         if let Some(candidates) = self.requirement_to_sorted_candidates.get(&requirement) {
             return Ok(candidates);
@@ -340,15 +340,15 @@ impl<D: DependencyProvider> SolverCache<D> {
     pub async fn get_or_cache_dependencies(
         &self,
         solvable_id: SolvableId,
-    ) -> Result<&Dependencies, Box<dyn Any>> {
+    ) -> Result<&Dependencies, String> {
         let dependencies_id = match self.solvable_to_dependencies.get_copy(&solvable_id) {
             Some(id) => id,
             None => {
                 // Since getting the dependencies from the provider is a potentially blocking
                 // operation, we want to check beforehand whether we should cancel the solving
                 // process
-                if let Some(value) = self.provider.should_cancel_with_value() {
-                    return Err(value);
+                if let Some(reason) = self.provider.should_cancel_with_reason() {
+                    return Err(reason);
                 }
 
                 let dependencies = self.provider.get_dependencies(solvable_id).await;

--- a/src/solver/encoding.rs
+++ b/src/solver/encoding.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, future::ready};
+use std::future::ready;
 
 use futures::{
     FutureExt, StreamExt, TryFutureExt, future::LocalBoxFuture, stream::FuturesUnordered,
@@ -36,8 +36,7 @@ pub(crate) struct Encoder<'a, 'cache, D: DependencyProvider> {
     root_dependencies: &'cache Dependencies,
 
     /// The set of futures that are pending to be resolved.
-    pending_futures:
-        FuturesUnordered<LocalBoxFuture<'cache, Result<TaskResult<'cache>, Box<dyn Any>>>>,
+    pending_futures: FuturesUnordered<LocalBoxFuture<'cache, Result<TaskResult<'cache>, String>>>,
 
     /// A list of clauses that were introduced that are conflicting with the
     /// current state.
@@ -114,7 +113,7 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
     pub async fn encode(
         mut self,
         solvable_ids: impl IntoIterator<Item = SolvableOrRootId>,
-    ) -> Result<Vec<ClauseId>, Box<dyn Any>> {
+    ) -> Result<Vec<ClauseId>, String> {
         // Queue the initial solvables for processing.
         for solvable_id in solvable_ids {
             self.queue_solvable(solvable_id);

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, fmt::Display, ops::ControlFlow};
+use std::{fmt::Display, ops::ControlFlow};
 
 use ahash::{HashMap, HashSet};
 pub use cache::SolverCache;
@@ -214,11 +214,15 @@ impl<D: DependencyProvider> Solver<D, NowOrNeverRuntime> {
 
 /// The root cause of a solver error.
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum UnsolvableOrCancelled {
     /// The problem was unsolvable.
     Unsolvable(Conflict),
     /// The solving process was cancelled.
-    Cancelled(Box<dyn Any>),
+    Cancelled {
+        /// Human-readable reason for cancellation
+        reason: String,
+    },
 }
 
 impl From<Conflict> for UnsolvableOrCancelled {
@@ -227,9 +231,47 @@ impl From<Conflict> for UnsolvableOrCancelled {
     }
 }
 
-impl From<Box<dyn Any>> for UnsolvableOrCancelled {
-    fn from(value: Box<dyn Any>) -> Self {
-        UnsolvableOrCancelled::Cancelled(value)
+impl From<String> for UnsolvableOrCancelled {
+    fn from(reason: String) -> Self {
+        UnsolvableOrCancelled::Cancelled { reason }
+    }
+}
+
+impl UnsolvableOrCancelled {
+    /// Returns `true` if the error is an unsolvable conflict.
+    pub fn is_unsolvable(&self) -> bool {
+        matches!(self, UnsolvableOrCancelled::Unsolvable(_))
+    }
+
+    /// Returns `true` if the error is due to cancellation.
+    pub fn is_cancelled(&self) -> bool {
+        matches!(self, UnsolvableOrCancelled::Cancelled { .. })
+    }
+
+    /// Returns a reference to the conflict if this is an unsolvable error.
+    pub fn as_unsolvable(&self) -> Option<&Conflict> {
+        match self {
+            UnsolvableOrCancelled::Unsolvable(conflict) => Some(conflict),
+            UnsolvableOrCancelled::Cancelled { .. } => None,
+        }
+    }
+
+    /// Serializes the error to JSON format.
+    #[cfg(feature = "json")]
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+
+    /// Serializes the error to pretty-printed JSON format.
+    #[cfg(feature = "json")]
+    pub fn to_json_pretty(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Deserializes an error from JSON format.
+    #[cfg(feature = "json")]
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
     }
 }
 
@@ -237,7 +279,7 @@ impl From<Box<dyn Any>> for UnsolvableOrCancelled {
 #[derive(Debug)]
 pub(crate) enum PropagationError {
     Conflict(VariableId, bool, ClauseId),
-    Cancelled(Box<dyn Any>),
+    Cancelled(String),
 }
 
 impl Display for PropagationError {
@@ -250,8 +292,8 @@ impl Display for PropagationError {
                     solvable, value, clause
                 )
             }
-            PropagationError::Cancelled(_) => {
-                write!(f, "propagation was cancelled")
+            PropagationError::Cancelled(reason) => {
+                write!(f, "propagation was cancelled: {}", reason)
             }
         }
     }
@@ -312,7 +354,7 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
     /// unsolvable, it is simply not included in the solution.
     ///
     /// If the solution process is cancelled (see
-    /// [`DependencyProvider::should_cancel_with_value`]), returns an
+    /// [`DependencyProvider::should_cancel_with_reason`]), returns an
     /// [`UnsolvableOrCancelled::Cancelled`] containing the cancellation value.
     pub fn solve(
         &mut self,
@@ -390,7 +432,7 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
     /// an `Err` on no solution.
     ///
     /// If the solution process is cancelled (see
-    /// [`DependencyProvider::should_cancel_with_value`]),
+    /// [`DependencyProvider::should_cancel_with_reason`]),
     /// returns [`UnsolvableOrCancelled::Cancelled`] as an `Err`.
     fn run_sat(
         &mut self,
@@ -488,9 +530,9 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
                         continue;
                     }
                 }
-                Err(PropagationError::Cancelled(value)) => {
+                Err(PropagationError::Cancelled(reason)) => {
                     // Propagation was cancelled
-                    return Err(UnsolvableOrCancelled::Cancelled(value));
+                    return Err(UnsolvableOrCancelled::Cancelled { reason });
                 }
             }
 
@@ -656,9 +698,9 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
                     level = new_level;
                     tracing::debug!("╘══ Propagation completed");
                 }
-                Err(UnsolvableOrCancelled::Cancelled(value)) => {
+                Err(UnsolvableOrCancelled::Cancelled { reason }) => {
                     tracing::debug!("╘══ Propagation cancelled");
-                    return Err(UnsolvableOrCancelled::Cancelled(value));
+                    return Err(UnsolvableOrCancelled::Cancelled { reason });
                 }
                 Err(UnsolvableOrCancelled::Unsolvable(conflict)) => {
                     tracing::debug!("╘══ Propagation resulted in a conflict");
@@ -936,8 +978,8 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
                 Ok(()) => {
                     return Ok(level);
                 }
-                Err(PropagationError::Cancelled(value)) => {
-                    return Err(UnsolvableOrCancelled::Cancelled(value));
+                Err(PropagationError::Cancelled(reason)) => {
+                    return Err(UnsolvableOrCancelled::Cancelled { reason });
                 }
                 Err(PropagationError::Conflict(
                     conflicting_solvable,
@@ -1048,8 +1090,8 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
     /// solvable has become false, in which case it picks a new solvable to
     /// watch (if available) or triggers an assignment.
     fn propagate(&mut self, level: u32) -> Result<(), PropagationError> {
-        if let Some(value) = self.provider().should_cancel_with_value() {
-            return Err(PropagationError::Cancelled(value));
+        if let Some(reason) = self.provider().should_cancel_with_reason() {
+            return Err(PropagationError::Cancelled(reason));
         };
 
         // Add decisions from assertions and learned clauses. If any of these cause a
@@ -1465,6 +1507,93 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
         for activity in &mut self.state.name_activity {
             *activity *= self.activity_decay;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conflict::Conflict;
+
+    #[test]
+    #[cfg(feature = "json")]
+    fn test_unsolvable_json_serialization() {
+        let mut conflict = Conflict::default();
+        conflict.add_clause(ClauseId::install_root());
+
+        let error = UnsolvableOrCancelled::Unsolvable(conflict);
+        let json = error.to_json().expect("Should serialize to JSON");
+        assert!(json.contains("Unsolvable"));
+        assert!(json.contains("clauses"));
+
+        let pretty_json = error
+            .to_json_pretty()
+            .expect("Should serialize to pretty JSON");
+        assert!(pretty_json.contains("Unsolvable"));
+        assert!(pretty_json.contains("  "));
+
+        let deserialized =
+            UnsolvableOrCancelled::from_json(&json).expect("Should deserialize from JSON");
+
+        assert!(deserialized.is_unsolvable());
+        assert!(!deserialized.is_cancelled());
+
+        if let Some(deserialized_conflict) = deserialized.as_unsolvable() {
+            assert_eq!(deserialized_conflict.clause_count(), 1);
+        }
+    }
+
+    #[test]
+    fn test_error_introspection() {
+        let conflict = Conflict::default();
+        let unsolvable_error = UnsolvableOrCancelled::Unsolvable(conflict);
+        let cancelled_error = UnsolvableOrCancelled::Cancelled {
+            reason: "test".to_string(),
+        };
+
+        assert!(unsolvable_error.is_unsolvable());
+        assert!(!unsolvable_error.is_cancelled());
+        assert!(unsolvable_error.as_unsolvable().is_some());
+
+        assert!(!cancelled_error.is_unsolvable());
+        assert!(cancelled_error.is_cancelled());
+        assert!(cancelled_error.as_unsolvable().is_none());
+    }
+
+    #[test]
+    fn test_conflict_clause_count() {
+        let mut conflict = Conflict::default();
+        assert_eq!(conflict.clause_count(), 0);
+
+        conflict.add_clause(ClauseId::install_root());
+        assert_eq!(conflict.clause_count(), 1);
+
+        conflict.add_clause(ClauseId::install_root());
+        assert_eq!(conflict.clause_count(), 1);
+    }
+
+    #[test]
+    #[cfg(feature = "json")]
+    fn test_cancelled_error_serialization() {
+        let cancelled_error = UnsolvableOrCancelled::Cancelled {
+            reason: "test cancellation".to_string(),
+        };
+        let result = cancelled_error
+            .to_json()
+            .expect("Should serialize successfully");
+        assert!(result.contains("Cancelled"));
+        assert!(result.contains("test cancellation"));
+
+        let deserialized = UnsolvableOrCancelled::from_json(&result).expect("Should deserialize");
+        assert!(deserialized.is_cancelled());
+        assert!(!deserialized.is_unsolvable());
+
+        let pretty_result = cancelled_error
+            .to_json_pretty()
+            .expect("Should serialize pretty");
+        assert!(pretty_result.contains("Cancelled"));
+        assert!(pretty_result.contains("test cancellation"));
+        assert!(pretty_result.contains("  "));
     }
 }
 

--- a/tests/solver/bundle_box/mod.rs
+++ b/tests/solver/bundle_box/mod.rs
@@ -21,7 +21,6 @@ pub mod parser;
 mod spec;
 
 use std::{
-    any::Any,
     cell::{Cell, RefCell},
     collections::HashSet,
     fmt::Display,
@@ -421,9 +420,9 @@ impl DependencyProvider for BundleBoxProvider {
         self.maybe_delay(Dependencies::Known(result)).await
     }
 
-    fn should_cancel_with_value(&self) -> Option<Box<dyn Any>> {
+    fn should_cancel_with_reason(&self) -> Option<String> {
         if self.cancel_solving.get() {
-            Some(Box::new("cancelled!".to_string()))
+            Some("cancelled!".to_string())
         } else {
             None
         }

--- a/tests/solver/main.rs
+++ b/tests/solver/main.rs
@@ -47,7 +47,7 @@ fn solve_unsat(mut provider: BundleBoxProvider, specs: &[&str]) -> String {
             // Format a user friendly error message
             conflict.display_user_friendly(&solver).to_string()
         }
-        Err(UnsolvableOrCancelled::Cancelled(reason)) => *reason.downcast().unwrap(),
+        Err(UnsolvableOrCancelled::Cancelled { reason }) => reason,
     }
 }
 
@@ -80,7 +80,7 @@ fn solve_snapshot(mut provider: BundleBoxProvider, specs: &[&str]) -> String {
             // Format a user friendly error message
             conflict.display_user_friendly(&solver).to_string()
         }
-        Err(UnsolvableOrCancelled::Cancelled(reason)) => *reason.downcast().unwrap(),
+        Err(UnsolvableOrCancelled::Cancelled { reason }) => reason,
     }
 }
 
@@ -1066,6 +1066,6 @@ fn solve_for_snapshot<D: DependencyProvider>(
             // Format a user friendly error message
             conflict.display_user_friendly(&solver).to_string()
         }
-        Err(UnsolvableOrCancelled::Cancelled(reason)) => *reason.downcast().unwrap(),
+        Err(UnsolvableOrCancelled::Cancelled { reason }) => reason,
     }
 }


### PR DESCRIPTION
closes https://github.com/prefix-dev/resolvo/issues/7

will also close this one too hopefully: https://github.com/prefix-dev/rip/issues/104


- Changed from `Box<dyn Any>>` to Option Type string to get the same (can be or cannot be! xD) outcome but with serialization and deserialization options
- Made the error output both human readable and machine readable, otherwise it would be just node numbers and it would be difficult to differ the actual error output. To this end i introduced a new mapping to get the correct errors from our complexgraph using HashMap
- I tried to minimize the usage of strings but really couldn't be helped since we will just need json anyways, to at least introduce some type-safety i made some of the types enum and used them instead of directly using strings to reduce string overhead + reduce future bugs
- Made an example to show lossless conversion is possible and output is there as an json if users (and we) want to check

