### PR TITLE
chore: release v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.10.1...resolvo-v0.10.2) - 2025-09-08
+
+### Added
+
+- update rust to 1.89.0 toolchain and add 1.85.1 msrv ([#167](https://github.com/prefix-dev/resolvo/pull/167))
+
+### Other
+
+- *(ci)* bump MarcoIeni/release-plz-action from 0.5.112 to 0.5.114 ([#173](https://github.com/prefix-dev/resolvo/pull/173))
+- *(ci)* bump actions-rust-lang/setup-rust-toolchain ([#171](https://github.com/prefix-dev/resolvo/pull/171))
+- *(ci)* bump MarcoIeni/release-plz-action from 0.5.110 to 0.5.112 ([#169](https://github.com/prefix-dev/resolvo/pull/169))
+- *(ci)* bump prefix-dev/setup-pixi from 0.8.14 to 0.9.0 ([#170](https://github.com/prefix-dev/resolvo/pull/170))
+- *(ci)* bump actions/checkout from 4.2.2 to 5.0.0 ([#165](https://github.com/prefix-dev/resolvo/pull/165))
+
 ## [0.10.1](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.10.0...resolvo-v0.10.1) - 2025-07-30
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resolvo"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "ahash",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cpp", "tools/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.1"
+version = "0.10.2"
 authors = [
     "Adolfo Ochagavía <github@adolfo.ochagavia.nl>",
     "Bas Zalmstra <zalmstra.bas@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `resolvo`: 0.10.1 -> 0.10.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.10.2](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.10.1...resolvo-v0.10.2) - 2025-09-08

### Added

- update rust to 1.89.0 toolchain and add 1.85.1 msrv ([#167](https://github.com/prefix-dev/resolvo/pull/167))

### Other

- *(ci)* bump MarcoIeni/release-plz-action from 0.5.112 to 0.5.114 ([#173](https://github.com/prefix-dev/resolvo/pull/173))
- *(ci)* bump actions-rust-lang/setup-rust-toolchain ([#171](https://github.com/prefix-dev/resolvo/pull/171))
- *(ci)* bump MarcoIeni/release-plz-action from 0.5.110 to 0.5.112 ([#169](https://github.com/prefix-dev/resolvo/pull/169))
- *(ci)* bump prefix-dev/setup-pixi from 0.8.14 to 0.9.0 ([#170](https://github.com/prefix-dev/resolvo/pull/170))
- *(ci)* bump actions/checkout from 4.2.2 to 5.0.0 ([#165](https://github.com/prefix-dev/resolvo/pull/165))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).