### PR TITLE
perf: bypass try_join_all for single requirements

### DIFF
--- a/src/solver/encoding.rs
+++ b/src/solver/encoding.rs
@@ -21,6 +21,33 @@ type PendingTask<'cache, D> = LocalBoxFuture<'cache, Result<TaskResult<'cache, D
 
 type RequirementCondition<'a, S> = Option<(ConditionId, Vec<Vec<DisjunctionComplement<'a, S>>>)>;
 
+/// Fetches each version set's sorted candidates while avoiding `try_join_all`'s
+/// per-future bookkeeping for the overwhelmingly common single-version-set case.
+/// Union members remain concurrent for dependency providers whose futures yield.
+async fn get_requirement_candidates<D: DependencyProvider>(
+    cache: &SolverCache<D>,
+    requirement: Requirement,
+) -> Result<Vec<&[D::SolvableId]>, Box<dyn Any>> {
+    match requirement {
+        Requirement::Single(version_set) => Ok(vec![
+            cache
+                .get_or_cache_sorted_candidates_for_version_set(version_set)
+                .await?,
+        ]),
+        Requirement::Union(version_set_union) => {
+            futures::future::try_join_all(
+                cache
+                    .provider()
+                    .version_sets_in_union(version_set_union)
+                    .map(|version_set| {
+                        cache.get_or_cache_sorted_candidates_for_version_set(version_set)
+                    }),
+            )
+            .await
+        }
+    }
+}
+
 /// An object that is responsible for encoding information from the dependency
 /// provider into rules and variables that are used by the solver.
 ///
@@ -853,15 +880,7 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
     ) {
         let cache = self.cache;
         self.queue_future(async move {
-            let candidates = futures::future::try_join_all(
-                requirement
-                    .requirement
-                    .version_sets(cache.provider())
-                    .map(|version_set| {
-                        cache.get_or_cache_sorted_candidates_for_version_set(version_set)
-                    }),
-            )
-            .await?;
+            let candidates = get_requirement_candidates(cache, requirement.requirement).await?;
 
             Ok(TaskResult::RequirementCandidates(
                 RequirementCandidatesAvailable {
@@ -1039,15 +1058,7 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
                 }))
                 .await?;
 
-            let candidates = futures::future::try_join_all(
-                requirement
-                    .requirement
-                    .version_sets(cache.provider())
-                    .map(|version_set| {
-                        cache.get_or_cache_sorted_candidates_for_version_set(version_set)
-                    }),
-            )
-            .await?;
+            let candidates = get_requirement_candidates(cache, requirement.requirement).await?;
 
             Ok(TaskResult::RequirementCandidates(
                 RequirementCandidatesAvailable {

--- a/tools/solve-snapshot/src/main.rs
+++ b/tools/solve-snapshot/src/main.rs
@@ -30,7 +30,7 @@ struct Opts {
 
     /// The timeout to use for solving requirements in seconds. If a solve takes
     /// longer if will be cancelled.
-    #[clap(long, default_value = "60")]
+    #[clap(long, default_value = "10")]
     timeout: u64,
 
     /// The random seed to use for generating the requirements.


### PR DESCRIPTION
Most requirements refer to a single version set, but candidate fetching still wraps each one in `try_join_all`. That adds per-future bookkeeping to a very common path.

This handles `Requirement::Single` directly and keeps `try_join_all` for unions, so union members remain concurrent when provider futures yield. It also changes `solve-snapshot`'s default per-solve timeout from 60 seconds to 10 seconds.

## Performance

On 2,000 fixed-seed cases in four rotated slices against `902eafe`:

| | Upstream main | This PR |
|---|---:|---:|
| Total | 673.7s | 582.3s (-13.58%) |
| Median | 256.2ms | 220.7ms |
| p95 | 808.0ms | 715.5ms |
| Max | 3708.2ms | 2171.8ms |

The paired workloads and solve/unsat outcomes matched. A separate tracking-allocator check reduced allocation count by 26.19% and allocated bytes by 37.58%; peak live memory was unchanged.

![Solve duration histogram](https://github.com/user-attachments/assets/2342017b-fb22-4037-b6d8-7672a6bb9940)

![Per-problem duration difference](https://github.com/user-attachments/assets/5ad4bb76-07b4-4b12-9106-938ea2b3afe4)

## Testing

- `pixi run -e test-rust cargo fmt --check`
- `pixi run -e test-rust cargo test --all-features`
